### PR TITLE
Changed autoloader handling, minor tweaks to unstick Travis.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+/build/
+/vendor/
 nbproject

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/autoload"]
-	path = vendor/autoload
-	url = git://github.com/versionable/Autoload.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: php
 
 php:
+  - 5.3.3
   - 5.3
   - 5.4
 
-script: phpunit
+before_script:
+  - composer install
+
+script: phpunit --verbose

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!-- see http://www.phpunit.de/wiki/Documentation -->
-<phpunit bootstrap="test/bootstrap.php"
+<phpunit bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,9 +1,0 @@
-<?php
-
-require_once(__DIR__.'/../vendor/autoload/src/Versionable/Autoload/Autoload.php');
-
-use Versionable\Autoload\Autoload;
-
-$al = new Autoload();
-$al->registerNamespace('Versionable', __DIR__.'/../src');
-$al->register();


### PR DESCRIPTION
With this change bootstrapping the project for testing only requires `composer install` to be run. This will setup Composer's autoloader (`vendor/autoload.php`) in such a way that Ferrit will be able to run tests.
- Removed the Git submodule
- Added additional files to .gitignore (`vendor/` and `build/`)
- Skip the `MIMEDetector` test if `MIME_Type` is not available
- Instruct Travis to run Composer
- Instruct Travis to test PHP 5.3.3 in addition to PHP 5.3 (latest stable)

---

One of the big things I'd like to move toward is **away** from `MIME_Type` entirely. I think a combination of some other projects would help us get away from this dependency.

This is going to require a lot of work with Composer. How comfortable are you with this projecting having external dependencies managed via Composer instead of Git submodules?

Let me know your thoughts on that direction. :)

Thanks!
