### PR TITLE
Skip MIME Type test if MIME_Type is not available.

### DIFF
--- a/test/Versionable/Ferret/Detector/MIMETypeTest.php
+++ b/test/Versionable/Ferret/Detector/MIMETypeTest.php
@@ -22,6 +22,10 @@ class MIMETypeTest extends \PHPUnit_Framework_TestCase {
    * This method is called before a test is executed.
    */
   protected function setUp() {
+    if (!class_exists('MIME_Type')) {
+      $this->markTestSkipped("Requires PEAR MIME_Type");
+    }
+
     $this->object = new MIMEType;
   }
 


### PR DESCRIPTION
It only ever will be available for someone who has MIME_Type installed in such a way that it will be autoloaded correctly. I'm not sure that is even possible so this may make this test a noop.

MIME_Type never will be available on Travis without work and this Detector will likely be phased out before that work can be done so this test will always be skipped on Travis.
